### PR TITLE
Vc/duplicated quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ This is a fork of the Metal Toolbox version of https://github.com/glerchundi/sql
 
 ## Installation
 
-Installation is simple, just use go get. Once the binary is in your path sqlboiler will be able to use it if you run it with the driver name `crdb`.
+Installation is simple, just use go get. Once the binary (`sqlboiler-crdb-fleetdb`) is in your GOPATH sqlboiler will be able to use it if you run it with the driver name `crdb-fleetdb`.
 ```
 # Install sqlboiler crdb driver
 go get -u github.com/metal-toolbox/sqlboiler-crdb-fleetdb/v4
 # Generate models
-sqlboiler crdb
+sqlboiler crdb-fleetdb
 ```
 It's configuration keys in sqlboiler are simple:
 ```
-[crdb]
+[crdb-fleetdb]
 user="root"
 pass=""
 host="localhost"
@@ -31,6 +31,8 @@ port=26257
 dbname="mydatabase"
 sslmode="disable"
 ```
+
+(The following is from the original repo README)
 
 **Notes**:
 * I don't plan to support other than latest version of SQLBoiler.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
-# sqlboiler-crdb
+# sqlboiler-crdb-fleetdb
 
 ## Original Source
 
-This is a fork from https://github.com/glerchundi/sqlboiler-crdb. We, the Metal Toolbox community, plan to maintain this fork and keep it active.
+This is a fork of the Metal Toolbox version of https://github.com/glerchundi/sqlboiler-crdb (found [here](https://github.com/infratographer/sqlboiler-crdb/v4)).
+
+## Development/Modification
+1. Clone this repository
+2. Run a CRDB container on port 26257
+3. Make your modifications.
+4. Build and test as normal.
+5. Push your branch, get reviewed, merge.
+6. Update the client to use the new version.
 
 ## Installation
 
 Installation is simple, just use go get. Once the binary is in your path sqlboiler will be able to use it if you run it with the driver name `crdb`.
 ```
 # Install sqlboiler crdb driver
-go get -u github.com/infratographer/sqlboiler-crdb/v4
+go get -u github.com/metal-toolbox/sqlboiler-crdb-fleetdb/v4
 # Generate models
 sqlboiler crdb
 ```

--- a/driver/crdb.go
+++ b/driver/crdb.go
@@ -9,8 +9,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/infratographer/sqlboiler-crdb/v4/driver/override"
 	_ "github.com/lib/pq" // Side-effect import sql driver
+	"github.com/metal-toolbox/sqlboiler-crdb-fleetdb/v4/driver/override"
 	"github.com/pkg/errors"
 	"github.com/volatiletech/sqlboiler/v4/drivers"
 	"github.com/volatiletech/sqlboiler/v4/importers"

--- a/driver/crdb.golden.json
+++ b/driver/crdb.golden.json
@@ -10,46 +10,49 @@
           "type": "int64",
           "db_type": "int8",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "post_id",
           "type": "int64",
           "db_type": "int8",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "content",
           "type": "null.String",
           "db_type": "string",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         }
       ],
       "p_key": {
-        "name": "primary",
+        "name": "comments_pkey",
         "columns": [
           "user_id",
           "post_id"
@@ -58,7 +61,12 @@
       "f_keys": null,
       "is_join_table": false,
       "to_one_relationships": null,
-      "to_many_relationships": null
+      "to_many_relationships": null,
+      "is_view": false,
+      "view_capabilities": {
+        "can_insert": false,
+        "can_upsert": false
+      }
     },
     {
       "name": "posts",
@@ -69,46 +77,49 @@
           "type": "int64",
           "db_type": "int8",
           "default": "unique_rowid()",
+          "comment": "",
           "nullable": false,
           "unique": true,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "user_id",
           "type": "null.Int64",
           "db_type": "int8",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "content",
           "type": "null.String",
           "db_type": "string",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         }
       ],
       "p_key": {
-        "name": "primary",
+        "name": "posts_pkey",
         "columns": [
           "id"
         ]
@@ -116,7 +127,7 @@
       "f_keys": [
         {
           "table": "posts",
-          "name": "fk_user_id_ref_users",
+          "name": "posts_user_id_fkey",
           "column": "user_id",
           "nullable": true,
           "unique": false,
@@ -128,7 +139,12 @@
       ],
       "is_join_table": false,
       "to_one_relationships": null,
-      "to_many_relationships": null
+      "to_many_relationships": null,
+      "is_view": false,
+      "view_capabilities": {
+        "can_insert": false,
+        "can_upsert": false
+      }
     },
     {
       "name": "sponsors",
@@ -139,18 +155,19 @@
           "type": "int64",
           "db_type": "int8",
           "default": "unique_rowid()",
+          "comment": "",
           "nullable": false,
           "unique": true,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         }
       ],
       "p_key": {
-        "name": "primary",
+        "name": "sponsors_pkey",
         "columns": [
           "id"
         ]
@@ -159,7 +176,7 @@
       "is_join_table": false,
       "to_one_relationships": [
         {
-          "name": "fk_sponsor_id_ref_sponsors",
+          "name": "videos_sponsor_id_fkey",
           "table": "sponsors",
           "column": "id",
           "nullable": false,
@@ -170,7 +187,12 @@
           "foreign_column_unique": true
         }
       ],
-      "to_many_relationships": null
+      "to_many_relationships": null,
+      "is_view": false,
+      "view_capabilities": {
+        "can_insert": false,
+        "can_upsert": false
+      }
     },
     {
       "name": "tags",
@@ -181,18 +203,19 @@
           "type": "int64",
           "db_type": "int8",
           "default": "unique_rowid()",
+          "comment": "",
           "nullable": false,
           "unique": true,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         }
       ],
       "p_key": {
-        "name": "primary",
+        "name": "tags_pkey",
         "columns": [
           "id"
         ]
@@ -213,16 +236,21 @@
           "foreign_column_unique": true,
           "to_join_table": true,
           "join_table": "video_tags",
-          "join_local_fkey_name": "fk_tag_id_ref_tags",
+          "join_local_fkey_name": "video_tags_tag_id_fkey",
           "join_local_column": "tag_id",
           "join_local_column_nullable": false,
           "join_local_column_unique": false,
-          "join_foreign_fkey_name": "fk_video_id_ref_videos",
+          "join_foreign_fkey_name": "video_tags_video_id_fkey",
           "join_foreign_column": "video_id",
           "join_foreign_column_nullable": false,
           "join_foreign_column_unique": false
         }
-      ]
+      ],
+      "is_view": false,
+      "view_capabilities": {
+        "can_insert": false,
+        "can_upsert": false
+      }
     },
     {
       "name": "type_monsters",
@@ -233,1572 +261,1684 @@
           "type": "int64",
           "db_type": "int8",
           "default": "unique_rowid()",
+          "comment": "",
           "nullable": false,
           "unique": true,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "bool_zero",
           "type": "null.Bool",
           "db_type": "bool",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "bool_one",
           "type": "null.Bool",
           "db_type": "bool",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "bool_two",
           "type": "bool",
           "db_type": "bool",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "bool_three",
           "type": "null.Bool",
           "db_type": "bool",
           "default": "false",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "bool_four",
           "type": "null.Bool",
           "db_type": "bool",
           "default": "true",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "bool_five",
           "type": "bool",
           "db_type": "bool",
           "default": "false",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "bool_six",
           "type": "bool",
           "db_type": "bool",
           "default": "true",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "string_zero",
           "type": "null.String",
           "db_type": "varchar",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "string_one",
           "type": "null.String",
           "db_type": "varchar",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "string_two",
           "type": "string",
           "db_type": "varchar",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "string_three",
           "type": "null.String",
           "db_type": "varchar",
-          "default": "'a':::STRING",
+          "default": "'a'",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "string_four",
           "type": "string",
           "db_type": "varchar",
-          "default": "'b':::STRING",
+          "default": "'b'",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "string_five",
           "type": "null.String",
           "db_type": "varchar",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "string_six",
           "type": "null.String",
           "db_type": "varchar",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "string_seven",
           "type": "string",
           "db_type": "varchar",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "string_eight",
           "type": "null.String",
           "db_type": "varchar",
-          "default": "'abcdefgh':::STRING",
+          "default": "'abcdefgh'",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "string_nine",
           "type": "string",
           "db_type": "varchar",
-          "default": "'abcdefgh':::STRING",
+          "default": "'abcdefgh'",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "string_ten",
           "type": "null.String",
           "db_type": "varchar",
-          "default": "'':::STRING",
+          "default": "''",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "string_eleven",
           "type": "string",
           "db_type": "varchar",
-          "default": "'':::STRING",
+          "default": "''",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "nonbyte_zero",
           "type": "null.String",
           "db_type": "char",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "nonbyte_one",
           "type": "null.String",
           "db_type": "char",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "nonbyte_two",
           "type": "string",
           "db_type": "char",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "nonbyte_three",
           "type": "null.String",
           "db_type": "char",
-          "default": "'a':::STRING",
+          "default": "'a'",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "nonbyte_four",
           "type": "string",
           "db_type": "char",
-          "default": "'b':::STRING",
+          "default": "'b'",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "nonbyte_five",
           "type": "null.String",
           "db_type": "char",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "nonbyte_six",
           "type": "null.String",
           "db_type": "char",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "nonbyte_seven",
           "type": "string",
           "db_type": "char",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "nonbyte_eight",
           "type": "null.String",
           "db_type": "char",
-          "default": "'a':::STRING",
+          "default": "'a'",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "nonbyte_nine",
           "type": "string",
           "db_type": "char",
-          "default": "'b':::STRING",
+          "default": "'b'",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "byte_zero",
           "type": "null.Byte",
           "db_type": "\"char\"",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "byte_one",
           "type": "null.Byte",
           "db_type": "\"char\"",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "byte_two",
           "type": "null.Byte",
           "db_type": "\"char\"",
-          "default": "'a':::STRING",
+          "default": "'a'",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "byte_three",
           "type": "types.Byte",
           "db_type": "\"char\"",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "byte_four",
           "type": "types.Byte",
           "db_type": "\"char\"",
-          "default": "'b':::STRING",
+          "default": "'b'",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "big_int_zero",
           "type": "null.Int64",
           "db_type": "int8",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "big_int_one",
           "type": "null.Int64",
           "db_type": "int8",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "big_int_two",
           "type": "int64",
           "db_type": "int8",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "big_int_three",
           "type": "null.Int64",
           "db_type": "int8",
-          "default": "111111:::INT8",
+          "default": "111111",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "big_int_four",
           "type": "int64",
           "db_type": "int8",
-          "default": "222222:::INT8",
+          "default": "222222",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "big_int_five",
           "type": "null.Int64",
           "db_type": "int8",
-          "default": "0:::INT8",
+          "default": "0",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "big_int_six",
           "type": "int64",
           "db_type": "int8",
-          "default": "0:::INT8",
+          "default": "0",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "int_zero",
           "type": "null.Int64",
           "db_type": "int8",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "int_one",
           "type": "null.Int64",
           "db_type": "int8",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "int_two",
           "type": "int64",
           "db_type": "int8",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "int_three",
           "type": "null.Int64",
           "db_type": "int8",
-          "default": "333333:::INT8",
+          "default": "333333",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "int_four",
           "type": "int64",
           "db_type": "int8",
-          "default": "444444:::INT8",
+          "default": "444444",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "int_five",
           "type": "null.Int64",
           "db_type": "int8",
-          "default": "0:::INT8",
+          "default": "0",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "int_six",
           "type": "int64",
           "db_type": "int8",
-          "default": "0:::INT8",
+          "default": "0",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "float_zero",
           "type": "types.NullDecimal",
           "db_type": "decimal",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "float_one",
           "type": "types.NullDecimal",
           "db_type": "decimal",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "float_two",
           "type": "types.NullDecimal",
           "db_type": "decimal",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "float_three",
           "type": "types.NullDecimal",
           "db_type": "decimal",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "float_four",
           "type": "types.NullDecimal",
           "db_type": "decimal",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "float_five",
           "type": "types.Decimal",
           "db_type": "decimal",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "float_six",
           "type": "types.NullDecimal",
           "db_type": "decimal",
-          "default": "1.1:::DECIMAL",
+          "default": "1.1",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "float_seven",
           "type": "types.Decimal",
           "db_type": "decimal",
-          "default": "1.1:::DECIMAL",
+          "default": "1.1",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "float_eight",
           "type": "types.NullDecimal",
           "db_type": "decimal",
-          "default": "0.0:::DECIMAL",
+          "default": "0.0",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "float_nine",
           "type": "types.NullDecimal",
           "db_type": "decimal",
-          "default": "0.0:::DECIMAL",
+          "default": "0.0",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "float_ten",
           "type": "null.Float64",
           "db_type": "float8",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "bytea_zero",
           "type": "null.Bytes",
           "db_type": "bytes",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "bytea_one",
           "type": "null.Bytes",
           "db_type": "bytes",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "bytea_two",
           "type": "[]byte",
           "db_type": "bytes",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "bytea_three",
           "type": "[]byte",
           "db_type": "bytes",
-          "default": "'\\x61':::BYTES",
+          "default": "'\\x61'",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "bytea_four",
           "type": "null.Bytes",
           "db_type": "bytes",
-          "default": "'\\x62':::BYTES",
+          "default": "'\\x62'",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "bytea_five",
           "type": "[]byte",
           "db_type": "bytes",
-          "default": "'\\x616263646566676861626364656667686162636465666768':::BYTES",
+          "default": "'\\x616263646566676861626364656667686162636465666768'",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "bytea_six",
           "type": "null.Bytes",
           "db_type": "bytes",
-          "default": "'\\x686766656463626168676665646362616867666564636261':::BYTES",
+          "default": "'\\x686766656463626168676665646362616867666564636261'",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "bytea_seven",
           "type": "[]byte",
           "db_type": "bytes",
-          "default": "'\\x':::BYTES",
+          "default": "'\\x'",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "bytea_eight",
           "type": "[]byte",
           "db_type": "bytes",
-          "default": "'\\x':::BYTES",
+          "default": "'\\x'",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "time_zero",
           "type": "null.Time",
           "db_type": "timestamp",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "time_one",
           "type": "null.Time",
           "db_type": "date",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "time_two",
           "type": "null.Time",
           "db_type": "timestamp",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "time_three",
           "type": "null.Time",
           "db_type": "timestamp",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "time_four",
           "type": "time.Time",
           "db_type": "timestamp",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "time_five",
           "type": "null.Time",
           "db_type": "timestamp",
-          "default": "'1999-01-08 04:05:06.789+00:00':::TIMESTAMP",
+          "default": "'1999-01-08 04:05:06.789'",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "time_six",
           "type": "null.Time",
           "db_type": "timestamp",
-          "default": "'1999-01-08 04:05:06.789+00:00':::TIMESTAMP",
+          "default": "'1999-01-08 04:05:06.789'",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "time_seven",
           "type": "time.Time",
           "db_type": "timestamp",
-          "default": "'1999-01-08 04:05:06.789+00:00':::TIMESTAMP",
+          "default": "'1999-01-08 04:05:06.789'",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "time_eight",
           "type": "time.Time",
           "db_type": "timestamp",
-          "default": "'1999-01-08 04:05:06.789+00:00':::TIMESTAMP",
+          "default": "'1999-01-08 04:05:06.789'",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "time_ten",
           "type": "null.Time",
           "db_type": "date",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "time_eleven",
           "type": "time.Time",
           "db_type": "date",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "time_twelve",
           "type": "null.Time",
           "db_type": "date",
-          "default": "'1999-01-08':::DATE",
+          "default": "'1999-01-08'",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "time_thirteen",
           "type": "time.Time",
           "db_type": "date",
-          "default": "'1999-01-08':::DATE",
+          "default": "'1999-01-08'",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "uuid_zero",
           "type": "null.String",
           "db_type": "uuid",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "uuid_one",
           "type": "null.String",
           "db_type": "uuid",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "uuid_two",
           "type": "null.String",
           "db_type": "uuid",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "uuid_three",
           "type": "string",
           "db_type": "uuid",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "uuid_four",
           "type": "null.String",
           "db_type": "uuid",
-          "default": "'6ba7b810-9dad-11d1-80b4-00c04fd430c8':::UUID",
+          "default": "'6ba7b810-9dad-11d1-80b4-00c04fd430c8'",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "uuid_five",
           "type": "string",
           "db_type": "uuid",
-          "default": "'6ba7b810-9dad-11d1-80b4-00c04fd430c8':::UUID",
+          "default": "'6ba7b810-9dad-11d1-80b4-00c04fd430c8'",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "integer_default",
           "type": "null.Int64",
           "db_type": "int8",
-          "default": "5:::INT8::INT8",
+          "default": "5",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "varchar_default",
           "type": "null.String",
           "db_type": "varchar",
-          "default": "5:::INT8::VARCHAR",
+          "default": "5::VARCHAR",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "timestamp_notz",
           "type": "null.Time",
           "db_type": "timestamp",
-          "default": "now():::TIMESTAMP",
+          "default": "now()",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "timestamp_tz",
           "type": "null.Time",
           "db_type": "timestamptz",
-          "default": "now():::TIMESTAMPTZ",
+          "default": "now()",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "interval_nnull",
           "type": "string",
           "db_type": "interval",
-          "default": "'21 days':::INTERVAL",
+          "default": "'21 days'",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "interval_null",
           "type": "null.String",
           "db_type": "interval",
-          "default": "'23:00:00':::INTERVAL",
+          "default": "'23:00:00'",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "json_null",
           "type": "null.JSON",
           "db_type": "jsonb",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "json_nnull",
           "type": "types.JSON",
           "db_type": "jsonb",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "jsonb_null",
           "type": "null.JSON",
           "db_type": "jsonb",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "jsonb_nnull",
           "type": "types.JSON",
           "db_type": "jsonb",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "double_prec_null",
           "type": "null.Float64",
           "db_type": "float8",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "double_prec_nnull",
           "type": "float64",
           "db_type": "float8",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "inet_null",
           "type": "null.String",
           "db_type": "inet",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "inet_nnull",
           "type": "string",
           "db_type": "inet",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "intarr_null",
           "type": "types.Int64Array",
           "db_type": "ARRAYint8",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": "int8",
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "intarr_nnull",
           "type": "types.Int64Array",
           "db_type": "ARRAYint8",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": "int8",
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "boolarr_null",
           "type": "types.BoolArray",
           "db_type": "ARRAYbool",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": "bool",
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "boolarr_nnull",
           "type": "types.BoolArray",
           "db_type": "ARRAYbool",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": "bool",
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "varchararr_null",
           "type": "types.StringArray",
           "db_type": "ARRAYvarchar",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": "varchar",
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "varchararr_nnull",
           "type": "types.StringArray",
           "db_type": "ARRAYvarchar",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": "varchar",
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "decimalarr_null",
           "type": "types.DecimalArray",
           "db_type": "ARRAYdecimal",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": "decimal",
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "decimalarr_nnull",
           "type": "types.DecimalArray",
           "db_type": "ARRAYdecimal",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": "decimal",
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "byteaarr_null",
           "type": "types.BytesArray",
           "db_type": "ARRAYbytes",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": "bytes",
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "byteaarr_nnull",
           "type": "types.BytesArray",
           "db_type": "ARRAYbytes",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": "bytes",
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         }
       ],
       "p_key": {
-        "name": "primary",
+        "name": "type_monsters_pkey",
         "columns": [
           "id"
         ]
@@ -1806,7 +1946,12 @@
       "f_keys": null,
       "is_join_table": false,
       "to_one_relationships": null,
-      "to_many_relationships": null
+      "to_many_relationships": null,
+      "is_view": false,
+      "view_capabilities": {
+        "can_insert": false,
+        "can_upsert": false
+      }
     },
     {
       "name": "users",
@@ -1817,18 +1962,19 @@
           "type": "int64",
           "db_type": "int8",
           "default": "unique_rowid()",
+          "comment": "",
           "nullable": false,
           "unique": true,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         }
       ],
       "p_key": {
-        "name": "primary",
+        "name": "users_pkey",
         "columns": [
           "id"
         ]
@@ -1838,7 +1984,7 @@
       "to_one_relationships": null,
       "to_many_relationships": [
         {
-          "name": "fk_user_id_ref_users",
+          "name": "posts_user_id_fkey",
           "table": "users",
           "column": "id",
           "nullable": false,
@@ -1859,7 +2005,7 @@
           "join_foreign_column_unique": false
         },
         {
-          "name": "fk_user_id_ref_users",
+          "name": "videos_user_id_fkey",
           "table": "users",
           "column": "id",
           "nullable": false,
@@ -1879,7 +2025,12 @@
           "join_foreign_column_nullable": false,
           "join_foreign_column_unique": false
         }
-      ]
+      ],
+      "is_view": false,
+      "view_capabilities": {
+        "can_insert": false,
+        "can_upsert": false
+      }
     },
     {
       "name": "video_tags",
@@ -1890,32 +2041,34 @@
           "type": "int64",
           "db_type": "int8",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "tag_id",
           "type": "int64",
           "db_type": "int8",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         }
       ],
       "p_key": {
-        "name": "primary",
+        "name": "video_tags_pkey",
         "columns": [
           "video_id",
           "tag_id"
@@ -1924,7 +2077,7 @@
       "f_keys": [
         {
           "table": "video_tags",
-          "name": "fk_video_id_ref_videos",
+          "name": "video_tags_video_id_fkey",
           "column": "video_id",
           "nullable": false,
           "unique": false,
@@ -1935,7 +2088,7 @@
         },
         {
           "table": "video_tags",
-          "name": "fk_tag_id_ref_tags",
+          "name": "video_tags_tag_id_fkey",
           "column": "tag_id",
           "nullable": false,
           "unique": false,
@@ -1947,7 +2100,12 @@
       ],
       "is_join_table": true,
       "to_one_relationships": null,
-      "to_many_relationships": null
+      "to_many_relationships": null,
+      "is_view": false,
+      "view_capabilities": {
+        "can_insert": false,
+        "can_upsert": false
+      }
     },
     {
       "name": "videos",
@@ -1958,46 +2116,49 @@
           "type": "int64",
           "db_type": "int8",
           "default": "unique_rowid()",
+          "comment": "",
           "nullable": false,
           "unique": true,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "user_id",
           "type": "int64",
           "db_type": "int8",
           "default": "",
+          "comment": "",
           "nullable": false,
           "unique": false,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         },
         {
           "name": "sponsor_id",
           "type": "null.Int64",
           "db_type": "int8",
-          "default": "",
+          "default": "NULL",
+          "comment": "",
           "nullable": true,
           "unique": true,
           "validated": false,
+          "auto_generated": false,
           "arr_type": null,
           "udt_name": "",
           "domain_name": null,
-          "full_db_type": "",
-          "auto_generated": false
+          "full_db_type": ""
         }
       ],
       "p_key": {
-        "name": "primary",
+        "name": "videos_pkey",
         "columns": [
           "id"
         ]
@@ -2005,7 +2166,7 @@
       "f_keys": [
         {
           "table": "videos",
-          "name": "fk_user_id_ref_users",
+          "name": "videos_user_id_fkey",
           "column": "user_id",
           "nullable": false,
           "unique": false,
@@ -2016,7 +2177,7 @@
         },
         {
           "table": "videos",
-          "name": "fk_sponsor_id_ref_sponsors",
+          "name": "videos_sponsor_id_fkey",
           "column": "sponsor_id",
           "nullable": true,
           "unique": true,
@@ -2041,16 +2202,21 @@
           "foreign_column_unique": true,
           "to_join_table": true,
           "join_table": "video_tags",
-          "join_local_fkey_name": "fk_video_id_ref_videos",
+          "join_local_fkey_name": "video_tags_video_id_fkey",
           "join_local_column": "video_id",
           "join_local_column_nullable": false,
           "join_local_column_unique": false,
-          "join_foreign_fkey_name": "fk_tag_id_ref_tags",
+          "join_foreign_fkey_name": "video_tags_tag_id_fkey",
           "join_foreign_column": "tag_id",
           "join_foreign_column_nullable": false,
           "join_foreign_column_unique": false
         }
-      ]
+      ],
+      "is_view": false,
+      "view_capabilities": {
+        "can_insert": false,
+        "can_upsert": false
+      }
     }
   ],
   "dialect": {
@@ -2060,9 +2226,9 @@
     "use_last_insert_id": false,
     "use_schema": false,
     "use_default_keyword": true,
-    "use_auto_columns": false,
     "use_top_clause": false,
     "use_output_clause": false,
-    "use_case_when_exists_clause": false
+    "use_case_when_exists_clause": false,
+    "use_auto_columns": false
   }
 }

--- a/driver/override/templates_test/singleton/crdb_main_test.go.tpl
+++ b/driver/override/templates_test/singleton/crdb_main_test.go.tpl
@@ -26,12 +26,12 @@ func init() {
 func (c *crdbTester) setup() error {
   var err error
 
-  c.dbName = viper.GetString("crdb.dbname")
-  c.host = viper.GetString("crdb.host")
-  c.user = viper.GetString("crdb.user")
-  c.pass = viper.GetString("crdb.pass")
-  c.port = viper.GetInt("crdb.port")
-  c.sslmode = viper.GetString("crdb.sslmode")
+  c.dbName = viper.GetString("crdb-fleetdb.dbname")
+  c.host = viper.GetString("crdb-fleetdb.host")
+  c.user = viper.GetString("crdb-fleetdb.user")
+  c.pass = viper.GetString("crdb-fleetdb.pass")
+  c.port = viper.GetInt("crdb-fleetdb.port")
+  c.sslmode = viper.GetString("crdb-fleetdb.sslmode")
   // Create a randomized db name.
   c.testDBName = randomize.StableDBName(c.dbName)
 

--- a/driver/override/templates_test/singleton/crdb_main_test.go.tpl
+++ b/driver/override/templates_test/singleton/crdb_main_test.go.tpl
@@ -53,14 +53,14 @@ func (c *crdbTester) setup() error {
   createCmd.Stdin = newShowCreateTableFilter(newFKeyDestroyer(rgxCDBFkey, r))
 
   if err = dumpCmd.Start(); err != nil {
-      return errors.Wrap(err, "failed to start 'cockroach dump' command")
+      return errors.Wrap(err, "failed to start cockroach show-create command")
   }
   if err = createCmd.Start(); err != nil {
-      return errors.Wrap(err, "failed to start 'cockroach sql' command")
+      return errors.Wrap(err, "failed to start 'cockroach sql' command for db create")
   }
 
   if err = dumpCmd.Wait(); err != nil {
-      return errors.Wrap(err, "failed to wait for 'cockroach sql' command")
+      return errors.Wrap(err, "failed to wait for cockroach show-create command")
   }
 
   // After dumpCmd is done, close the write end of the pipe
@@ -69,7 +69,7 @@ func (c *crdbTester) setup() error {
   }
 
   if err = createCmd.Wait(); err != nil {
-      return errors.Wrap(err, "failed to wait for 'cockroach sql' command")
+      return errors.Wrap(err, "failed to wait for 'cockroach sql' command for db create")
   }
 
   return nil

--- a/driver/override/templates_test/singleton/crdb_main_test.go.tpl
+++ b/driver/override/templates_test/singleton/crdb_main_test.go.tpl
@@ -176,6 +176,7 @@ func (f *showCreateFilter) Read(b []byte) (int, error) {
     all = bytes.Replace(all, []byte("create_statement"), []byte{}, -1)
     all = bytes.Replace(all, []byte("\"CREATE"), []byte("CREATE"), -1)
     all = bytes.Replace(all, []byte(";\""), []byte(";"), -1)
+    all = bytes.Replace(all, []byte(`""`), []byte(`"`), -1)
     f.buf = bytes.NewBuffer(all)
   }
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/infratographer/sqlboiler-crdb/v4
+module github.com/metal-toolbox/sqlboiler-crdb-fleetdb/v4
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/infratographer/sqlboiler-crdb/v4/driver"
+	"github.com/metal-toolbox/sqlboiler-crdb-fleetdb/v4/driver"
 	"github.com/volatiletech/sqlboiler/v4/drivers"
 )
 


### PR DESCRIPTION
The upstream for this driver does not handle the output of `SHOW ALL CREATE TABLES` properly, leaving instances of `""` in the output, which breaks when we attempt to use that output to create a new database. Here we address that issue, as well as a make a few small changes to assert our own identity and make some error messages clearer.